### PR TITLE
Fix reload for server

### DIFF
--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -8,6 +8,7 @@ const nextConfig: NextConfig = {
         unoptimized: true,
     },
     output: 'export',
+    trailingSlash: true,
 };
 
 export default nextConfig;


### PR DESCRIPTION
Fix reload for the server (https://github.com/basalt-rs/basalt-server/issues/49) by adding trailing slashes to the output (makes Next generate `/foo/index.html` instead of `/foo.html`)